### PR TITLE
internal: improve unit test coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,8 @@ vet: ## Run go vet against code.
 
 .PHONY: test
 test: manifests generate fmt vet setup-envtest ## Run tests.
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test $$(go list ./... | grep -v /e2e) -coverprofile cover.out
+#	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test $$(go list ./... | grep -v /e2e) -coverprofile cover.out
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test $$(go list ./... | grep -E 'pkg|internal') -coverprofile cover.out
 
 #KIND_CLUSTER ?= k8s-example-kubedredger-test-e2e
 KIND_CLUSTER ?= k8s-example-kubedredger-kind

--- a/go.mod
+++ b/go.mod
@@ -3,10 +3,14 @@ module golab.io/kubedredger
 go 1.24.5
 
 require (
+	github.com/go-logr/logr v1.4.2
+	github.com/google/go-cmp v0.7.0
 	github.com/onsi/ginkgo/v2 v2.22.0
 	github.com/onsi/gomega v1.36.1
+	k8s.io/api v0.33.0
 	k8s.io/apimachinery v0.33.0
 	k8s.io/client-go v0.33.0
+	k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738
 	sigs.k8s.io/controller-runtime v0.21.0
 )
 
@@ -23,7 +27,6 @@ require (
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
 	github.com/fxamacker/cbor/v2 v2.7.0 // indirect
-	github.com/go-logr/logr v1.4.2 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-logr/zapr v1.3.0 // indirect
 	github.com/go-openapi/jsonpointer v0.21.0 // indirect
@@ -34,7 +37,6 @@ require (
 	github.com/google/btree v1.1.3 // indirect
 	github.com/google/cel-go v0.23.2 // indirect
 	github.com/google/gnostic-models v0.6.9 // indirect
-	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/pprof v0.0.0-20241029153458-d1b30febd7db // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.24.0 // indirect
@@ -82,13 +84,11 @@ require (
 	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	k8s.io/api v0.33.0 // indirect
 	k8s.io/apiextensions-apiserver v0.33.0 // indirect
 	k8s.io/apiserver v0.33.0 // indirect
 	k8s.io/component-base v0.33.0 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20250318190949-c8a335a9a2ff // indirect
-	k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738 // indirect
 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.2 // indirect
 	sigs.k8s.io/json v0.0.0-20241010143419-9aa6b5e7a4b3 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect

--- a/internal/configfile/configfile_test.go
+++ b/internal/configfile/configfile_test.go
@@ -1,0 +1,167 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package configfile
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr/testr"
+	"github.com/google/go-cmp/cmp"
+)
+
+const (
+	minimalConfContent = "[main]\nfoo=bar\n"
+)
+
+func TestStatusFromEmpty(t *testing.T) {
+	tmpDir := t.TempDir()
+	confPath := filepath.Join(tmpDir, "workshop1.conf")
+	mgr := NewManager(confPath)
+	st := mgr.Status()
+	exp := ConfigurationStatus{}
+
+	if diff := cmp.Diff(st, exp); diff != "" {
+		t.Errorf("unexpected status: %v", diff)
+	}
+}
+
+func TestCreateFromScratch(t *testing.T) {
+	lh := testr.New(t)
+	ts := time.Now()
+	time.Sleep(51 * time.Millisecond) // ensure update time diff
+
+	tmpDir := t.TempDir()
+	confPath := filepath.Join(tmpDir, "workshop1.conf")
+	mgr := NewManager(confPath)
+	err := mgr.HandleSync(lh, ConfigRequest{
+		Content: minimalConfContent,
+		Create:  true,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	st := mgr.Status()
+	verifyFileExistsWithContent(t, st, confPath, minimalConfContent, ts)
+}
+
+func TestCreateNotSet(t *testing.T) {
+	lh := testr.New(t)
+
+	tmpDir := t.TempDir()
+	confPath := filepath.Join(tmpDir, "workshop1.conf")
+	mgr := NewManager(confPath)
+	err := mgr.HandleSync(lh, ConfigRequest{
+		Content: minimalConfContent,
+		Create:  false,
+	})
+	if err == nil {
+		t.Fatalf("create set, but file does not exist and this was allowed")
+	}
+}
+
+func TestCreateDelete(t *testing.T) {
+	lh := testr.New(t)
+	ts := time.Now()
+	time.Sleep(51 * time.Millisecond) // ensure update time diff
+
+	tmpDir := t.TempDir()
+	confPath := filepath.Join(tmpDir, "workshop1.conf")
+	mgr := NewManager(confPath)
+	err := mgr.HandleSync(lh, ConfigRequest{
+		Content: minimalConfContent,
+		Create:  true,
+	})
+	if err != nil {
+		t.Fatalf("unexpected sync error: %v", err)
+	}
+
+	st := mgr.Status()
+	verifyFileExistsWithContent(t, st, confPath, minimalConfContent, ts)
+
+	err = mgr.Delete()
+	if err != nil {
+		t.Fatalf("unexpected delete error: %v", err)
+	}
+
+	ok, err := FileExists(confPath)
+	if err != nil {
+		t.Fatalf("unexpected fileExists error: %v", err)
+	}
+	if ok {
+		t.Fatalf("file exists after deletion")
+	}
+}
+
+func TestCreateUpdate(t *testing.T) {
+	lh := testr.New(t)
+	ts := time.Now()
+	time.Sleep(51 * time.Millisecond) // ensure update time diff
+
+	tmpDir := t.TempDir()
+	confPath := filepath.Join(tmpDir, "workshop1.conf")
+	mgr := NewManager(confPath)
+	err := mgr.HandleSync(lh, ConfigRequest{
+		Content: minimalConfContent,
+		Create:  true,
+	})
+	if err != nil {
+		t.Fatalf("unexpected create error: %v", err)
+	}
+
+	st := mgr.Status()
+	verifyFileExistsWithContent(t, st, confPath, minimalConfContent, ts)
+
+	time.Sleep(51 * time.Millisecond) // ensure update time diff
+	content2 := `{\n"  foo": "bar"\n}`
+	err = mgr.HandleSync(lh, ConfigRequest{
+		Content: content2,
+	})
+	if err != nil {
+		t.Fatalf("unexpected create error: %v", err)
+	}
+
+	st2 := mgr.Status()
+	verifyFileExistsWithContent(t, st2, confPath, content2, ts)
+}
+
+func verifyFileExistsWithContent(t *testing.T, st ConfigurationStatus, confPath, content string, ts time.Time) {
+	t.Helper()
+	bindata, err := os.ReadFile(confPath)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	data := string(bindata)
+	if data != content {
+		t.Fatalf("unexpected content: got=%q wants=%q", data, content)
+	}
+	if st.FileUpdated.Before(ts) {
+		t.Fatalf("unexpected update: got=%v ref=%v", st.FileUpdated, ts)
+	}
+	st.FileUpdated = ts // normalize
+	expected := ConfigurationStatus{
+		FileExists:  true,
+		Content:     content,
+		FileUpdated: ts,
+	}
+	if diff := cmp.Diff(st, expected); diff != "" {
+		t.Fatalf("status mismatch: %v", diff)
+	}
+}

--- a/internal/controller/conversion.go
+++ b/internal/controller/conversion.go
@@ -59,8 +59,7 @@ func statusFromConfStatus(desired workshopv1alpha1.ConfigurationSpec, confStatus
 	if desired.Content != confStatus.Content && confStatus.LastWriteError != "" {
 		progressing.Status = metav1.ConditionTrue
 		progressing.Reason = ConditionReasonUpdatingContent
-	}
-	if labelErr != nil {
+	} else if labelErr != nil {
 		progressing.Status = metav1.ConditionTrue
 		progressing.Reason = ConditionReasonUpdatingLabels
 		progressing.Message = labelErr.Error()

--- a/internal/controller/conversion_test.go
+++ b/internal/controller/conversion_test.go
@@ -1,0 +1,94 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"testing"
+	"time"
+
+	workshopv1alpha1 "golab.io/kubedredger/api/v1alpha1"
+	"golab.io/kubedredger/internal/configfile"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestConversionDegraded(t *testing.T) {
+	fakeTs := time.Now()
+	fakeErrText := "fake error for testing"
+	var labelErr error // no error
+	st := statusFromConfStatus(
+		workshopv1alpha1.ConfigurationSpec{},
+		configfile.ConfigurationStatus{
+			LastWriteError: fakeErrText,
+			FileUpdated:    fakeTs,
+		},
+		labelErr)
+
+	if st.FileExists {
+		t.Fatalf("file exists on error")
+	}
+	cond := findCondition(st.Conditions, ConditionDegraded)
+	if cond == nil {
+		t.Fatalf("missing degraded condition")
+	}
+	if cond.Status != metav1.ConditionTrue {
+		t.Fatalf("condition not set")
+	}
+	if cond.Reason != ConditionReasonWriteError {
+		t.Fatalf("wrong reason: %q", cond.Reason)
+	}
+}
+
+func TestConversionProgressing(t *testing.T) {
+	fakeTs := time.Now()
+	var labelErr error // no error
+	st := statusFromConfStatus(
+		workshopv1alpha1.ConfigurationSpec{
+			Content: "foo=1\n",
+			Create:  true,
+		},
+		configfile.ConfigurationStatus{
+			LastWriteError: "no space left",
+			Content:        "foo=0\n",
+			FileExists:     true,
+			FileUpdated:    fakeTs,
+		},
+		labelErr)
+
+	if !st.FileExists {
+		t.Fatalf("file does not exist")
+	}
+	cond := findCondition(st.Conditions, ConditionProgressing)
+	if cond == nil {
+		t.Fatalf("missing degraded condition")
+	}
+	if cond.Status != metav1.ConditionTrue {
+		t.Fatalf("condition not set")
+	}
+	if cond.Reason != ConditionReasonUpdatingContent {
+		t.Fatalf("wrong reason: %q", cond.Reason)
+	}
+}
+
+func findCondition(conditions []metav1.Condition, condition string) *metav1.Condition {
+	for idx := 0; idx < len(conditions); idx++ {
+		cond := &conditions[idx]
+		if cond.Type == condition {
+			return cond
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
make sure all the business logic packages have at least 80% coverage
```
ok  	golab.io/kubedredger/internal/configfile	0.219s	coverage: 80.3% of statements
ok  	golab.io/kubedredger/internal/controller	4.268s	coverage: 82.3% of statements
ok  	golab.io/kubedredger/internal/nodelabel	0.013s	coverage: 96.4% of statements
```