### PR TITLE
feat: support for multiple config files

### DIFF
--- a/api/v1alpha1/configuration_types.go
+++ b/api/v1alpha1/configuration_types.go
@@ -22,6 +22,9 @@ import (
 
 // ConfigurationSpec defines the desired state of Configuration
 type ConfigurationSpec struct {
+	// Filename is the full name of the configuration file within the root
+	Filename string `json:"filename"`
+
 	// Content is the content to be written to the file
 	Content string `json:"content"`
 

--- a/config/crd/bases/workshop.golab.io_configurations.yaml
+++ b/config/crd/bases/workshop.golab.io_configurations.yaml
@@ -59,11 +59,18 @@ spec:
                 description: Create indicates whether to create the file if it does
                   not exist
                 type: boolean
+              filename:
+                description: Filename is the full name of the configuration file within
+                  the root
+                type: string
               permission:
+                description: 'Permission is the UNIX permission octal bit mask (example:
+                  0644) the file should have'
                 format: int32
                 type: integer
             required:
             - content
+            - filename
             type: object
           status:
             description: status defines the observed state of Configuration

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -30,26 +30,6 @@ spec:
         control-plane: controller-manager
         app.kubernetes.io/name: k8s-example-kubedredger
     spec:
-      # TODO(user): Uncomment the following code to configure the nodeAffinity expression
-      # according to the platforms which are supported by your solution.
-      # It is considered best practice to support multiple architectures. You can
-      # build your manager image using the makefile target docker-buildx.
-      # affinity:
-      #   nodeAffinity:
-      #     requiredDuringSchedulingIgnoredDuringExecution:
-      #       nodeSelectorTerms:
-      #         - matchExpressions:
-      #           - key: kubernetes.io/arch
-      #             operator: In
-      #             values:
-      #               - amd64
-      #               - arm64
-      #               - ppc64le
-      #               - s390x
-      #           - key: kubernetes.io/os
-      #             operator: In
-      #             values:
-      #               - linux
       securityContext:
         # Projects are configured by default to adhere to the "restricted" Pod Security Standards.
         # This ensures that deployments meet the highest security requirements for Kubernetes.
@@ -63,7 +43,7 @@ spec:
         args:
           - --leader-elect
           - --health-probe-bind-address=:8081
-          - --configuration-file=/host/tmp/config
+          - --configuration-root=/host/tmp/config.d
         image: controller:latest
         name: manager
         ports: []
@@ -84,8 +64,6 @@ spec:
             port: 8081
           initialDelaySeconds: 5
           periodSeconds: 10
-        # TODO(user): Configure the resources accordingly based on the project requirements.
-        # More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
         resources:
           limits:
             cpu: 500m

--- a/internal/configfile/configfile_test.go
+++ b/internal/configfile/configfile_test.go
@@ -27,14 +27,14 @@ import (
 )
 
 const (
+	defaultConfName    = "workshop.conf"
 	minimalConfContent = "[main]\nfoo=bar\n"
 )
 
 func TestStatusFromEmpty(t *testing.T) {
 	tmpDir := t.TempDir()
-	confPath := filepath.Join(tmpDir, "workshop1.conf")
-	mgr := NewManager(confPath)
-	st := mgr.Status()
+	mgr := NewManager(tmpDir)
+	st := mgr.Status(defaultConfName)
 	exp := ConfigurationStatus{}
 
 	if diff := cmp.Diff(st, exp); diff != "" {
@@ -48,17 +48,18 @@ func TestCreateFromScratch(t *testing.T) {
 	time.Sleep(51 * time.Millisecond) // ensure update time diff
 
 	tmpDir := t.TempDir()
-	confPath := filepath.Join(tmpDir, "workshop1.conf")
-	mgr := NewManager(confPath)
+	mgr := NewManager(tmpDir)
 	err := mgr.HandleSync(lh, ConfigRequest{
-		Content: minimalConfContent,
-		Create:  true,
+		Filename: defaultConfName,
+		Content:  minimalConfContent,
+		Create:   true,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	st := mgr.Status()
+	confPath := filepath.Join(tmpDir, defaultConfName)
+	st := mgr.Status(defaultConfName)
 	verifyFileExistsWithContent(t, st, confPath, minimalConfContent, ts)
 }
 
@@ -66,11 +67,11 @@ func TestCreateNotSet(t *testing.T) {
 	lh := testr.New(t)
 
 	tmpDir := t.TempDir()
-	confPath := filepath.Join(tmpDir, "workshop1.conf")
-	mgr := NewManager(confPath)
+	mgr := NewManager(tmpDir)
 	err := mgr.HandleSync(lh, ConfigRequest{
-		Content: minimalConfContent,
-		Create:  false,
+		Filename: defaultConfName,
+		Content:  minimalConfContent,
+		Create:   false,
 	})
 	if err == nil {
 		t.Fatalf("create set, but file does not exist and this was allowed")
@@ -83,20 +84,21 @@ func TestCreateDelete(t *testing.T) {
 	time.Sleep(51 * time.Millisecond) // ensure update time diff
 
 	tmpDir := t.TempDir()
-	confPath := filepath.Join(tmpDir, "workshop1.conf")
-	mgr := NewManager(confPath)
+	mgr := NewManager(tmpDir)
 	err := mgr.HandleSync(lh, ConfigRequest{
-		Content: minimalConfContent,
-		Create:  true,
+		Filename: defaultConfName,
+		Content:  minimalConfContent,
+		Create:   true,
 	})
 	if err != nil {
 		t.Fatalf("unexpected sync error: %v", err)
 	}
 
-	st := mgr.Status()
+	confPath := filepath.Join(tmpDir, defaultConfName)
+	st := mgr.Status(defaultConfName)
 	verifyFileExistsWithContent(t, st, confPath, minimalConfContent, ts)
 
-	err = mgr.Delete()
+	err = mgr.Delete(defaultConfName)
 	if err != nil {
 		t.Fatalf("unexpected delete error: %v", err)
 	}
@@ -116,29 +118,31 @@ func TestCreateUpdate(t *testing.T) {
 	time.Sleep(51 * time.Millisecond) // ensure update time diff
 
 	tmpDir := t.TempDir()
-	confPath := filepath.Join(tmpDir, "workshop1.conf")
-	mgr := NewManager(confPath)
+	mgr := NewManager(tmpDir)
 	err := mgr.HandleSync(lh, ConfigRequest{
-		Content: minimalConfContent,
-		Create:  true,
+		Filename: defaultConfName,
+		Content:  minimalConfContent,
+		Create:   true,
 	})
 	if err != nil {
 		t.Fatalf("unexpected create error: %v", err)
 	}
 
-	st := mgr.Status()
+	confPath := filepath.Join(tmpDir, defaultConfName)
+	st := mgr.Status(defaultConfName)
 	verifyFileExistsWithContent(t, st, confPath, minimalConfContent, ts)
 
 	time.Sleep(51 * time.Millisecond) // ensure update time diff
 	content2 := `{\n"  foo": "bar"\n}`
 	err = mgr.HandleSync(lh, ConfigRequest{
-		Content: content2,
+		Filename: defaultConfName,
+		Content:  content2,
 	})
 	if err != nil {
 		t.Fatalf("unexpected create error: %v", err)
 	}
 
-	st2 := mgr.Status()
+	st2 := mgr.Status(defaultConfName)
 	verifyFileExistsWithContent(t, st2, confPath, content2, ts)
 }
 

--- a/internal/controller/conversion.go
+++ b/internal/controller/conversion.go
@@ -23,8 +23,9 @@ const (
 
 func configurationRequestFromSpec(desired workshopv1alpha1.ConfigurationSpec) configfile.ConfigRequest {
 	res := configfile.ConfigRequest{
-		Content: desired.Content,
-		Create:  desired.Create,
+		Filename: desired.Filename,
+		Content:  desired.Content,
+		Create:   desired.Create,
 	}
 	if desired.Permission != nil {
 		res.Permission = ptr.To(*desired.Permission)

--- a/internal/nodelabel/nodelabel_test.go
+++ b/internal/nodelabel/nodelabel_test.go
@@ -164,7 +164,7 @@ func TestManagerSet(t *testing.T) {
 				},
 			},
 			nodeName:   "test-node",
-			labelKey:   ContentHash,
+			labelKey:   ContentHashV1,
 			labelValue: "test-fake-hash",
 			expectedOK: true,
 		},
@@ -176,7 +176,7 @@ func TestManagerSet(t *testing.T) {
 				},
 			},
 			nodeName:   "test-node",
-			labelKey:   ContentHash,
+			labelKey:   ContentHashV1,
 			labelValue: "test-fake-hash",
 			expectedOK: true,
 		},
@@ -186,12 +186,12 @@ func TestManagerSet(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-node",
 					Labels: map[string]string{
-						ContentHash: "test-fake-hash-old",
+						ContentHashV1: "test-fake-hash-old",
 					},
 				},
 			},
 			nodeName:   "test-node",
-			labelKey:   ContentHash,
+			labelKey:   ContentHashV1,
 			labelValue: "test-fake-hash-new",
 			expectedOK: true,
 		},
@@ -277,9 +277,9 @@ func TestManagerClear(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-node",
 					Labels: map[string]string{
-						ContentHash: "test-fake-hash",
-						"foo":       "quux",
-						"bar":       "42",
+						ContentHashV1: "test-fake-hash",
+						"foo":         "quux",
+						"bar":         "42",
 					},
 				},
 			},
@@ -298,7 +298,7 @@ func TestManagerClear(t *testing.T) {
 			cli := newFakeClient(tcase.node)
 			mgr := NewManager(tcase.nodeName, cli)
 			oldLabels := maps.Clone(tcase.node.Labels)
-			err := mgr.Clear(context.TODO())
+			err := mgr.Clear(context.TODO(), ContentHashV1)
 			ok := (err == nil)
 			if ok != tcase.expectedOK {
 				t.Fatalf("unexpected status. err=%v", err)

--- a/internal/validate/validate.go
+++ b/internal/validate/validate.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validate
+
+import (
+	"errors"
+	"os"
+
+	workshopv1alpha1 "golab.io/kubedredger/api/v1alpha1"
+)
+
+var (
+	ErrMissingFilename   = errors.New("filename can't be empty")
+	ErrInvalidPermission = errors.New("requested permissions are not a valid UNIX permission set")
+)
+
+func Request(spec workshopv1alpha1.ConfigurationSpec) error {
+	if spec.Filename == "" {
+		return ErrMissingFilename
+	}
+	if spec.Permission != nil {
+		return validPermission(*spec.Permission)
+	}
+	return nil
+}
+
+func validPermission(perm uint32) error {
+	// no spurious bits
+	if (os.FileMode(perm) & os.ModeType) != 0 {
+		return ErrInvalidPermission
+	}
+	return nil
+}

--- a/internal/validate/validate_test.go
+++ b/internal/validate/validate_test.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validate
+
+import (
+	"testing"
+
+	workshopv1alpha1 "golab.io/kubedredger/api/v1alpha1"
+	"k8s.io/utils/ptr"
+)
+
+func TestRequest(t *testing.T) {
+	type testCase struct {
+		name        string
+		spec        workshopv1alpha1.ConfigurationSpec
+		expectedErr error
+	}
+
+	testCases := []testCase{
+		{
+			name:        "empty",
+			spec:        workshopv1alpha1.ConfigurationSpec{},
+			expectedErr: ErrMissingFilename,
+		},
+		{
+			name: "good",
+			spec: workshopv1alpha1.ConfigurationSpec{
+				Filename:   "fooconf.json",
+				Content:    "{}",
+				Create:     true,
+				Permission: ptr.To[uint32](0644),
+			},
+			expectedErr: nil,
+		},
+		{
+			name: "empty content is fine",
+			spec: workshopv1alpha1.ConfigurationSpec{
+				Filename:   "fooconf.json",
+				Create:     true,
+				Permission: ptr.To[uint32](0644),
+			},
+			expectedErr: nil,
+		},
+		{
+			name: "bad permissions",
+			spec: workshopv1alpha1.ConfigurationSpec{
+				Filename:   "fooconf.json",
+				Create:     true,
+				Permission: ptr.To[uint32](0xCAFECAFE),
+			},
+			expectedErr: ErrInvalidPermission,
+		},
+	}
+
+	for _, tcase := range testCases {
+		t.Run(tcase.name, func(t *testing.T) {
+			gotErr := Request(tcase.spec)
+			if gotErr == nil && tcase.expectedErr == nil {
+				return
+			}
+			if gotErr == tcase.expectedErr {
+				return
+			}
+			t.Errorf("unexpected error got=%v expected=%v", gotErr, tcase.expectedErr)
+		})
+	}
+}


### PR DESCRIPTION
Add support to multiple files in the configuration root, which then becomes a dir, not a file.

The root is completely owned by the controller.
Requires and uses finalizers to learn which configuration file should be deleted.