### PR TITLE
Remove the labelling logic

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -38,7 +38,6 @@ import (
 	workshopv1alpha1 "golab.io/kubedredger/api/v1alpha1"
 	"golab.io/kubedredger/internal/configfile"
 	"golab.io/kubedredger/internal/controller"
-	"golab.io/kubedredger/internal/nodelabel"
 	// +kubebuilder:scaffold:imports
 )
 
@@ -192,10 +191,9 @@ func main() {
 
 	cli := mgr.GetClient()
 	if err := (&controller.ConfigurationReconciler{
-		Client:   cli,
-		Scheme:   mgr.GetScheme(),
-		ConfMgr:  confMgr,
-		Labeller: nodelabel.NewManager(nodeName, cli),
+		Client:  cli,
+		Scheme:  mgr.GetScheme(),
+		ConfMgr: confMgr,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Configuration")
 		os.Exit(1)

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -5,16 +5,6 @@ metadata:
   name: kubedredger-role
 rules:
 - apiGroups:
-  - ""
-  resources:
-  - nodes
-  verbs:
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
   - workshop.golab.io
   resources:
   - configurations

--- a/internal/controller/configuration_controller.go
+++ b/internal/controller/configuration_controller.go
@@ -47,7 +47,6 @@ type ConfigurationReconciler struct {
 // +kubebuilder:rbac:groups=workshop.golab.io,resources=configurations,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=workshop.golab.io,resources=configurations/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=workshop.golab.io,resources=configurations/finalizers,verbs=update
-// +kubebuilder:rbac:groups="",resources=nodes,verbs=get;update;patch;list;watch
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/internal/controller/configuration_controller.go
+++ b/internal/controller/configuration_controller.go
@@ -18,11 +18,8 @@ package controller
 
 import (
 	"context"
-	"crypto/sha256"
 	"errors"
 	"fmt"
-
-	"github.com/go-logr/logr"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -33,7 +30,6 @@ import (
 
 	workshopv1alpha1 "golab.io/kubedredger/api/v1alpha1"
 	"golab.io/kubedredger/internal/configfile"
-	"golab.io/kubedredger/internal/nodelabel"
 	"golab.io/kubedredger/internal/validate"
 )
 
@@ -44,9 +40,8 @@ const (
 // ConfigurationReconciler reconciles a Configuration object
 type ConfigurationReconciler struct {
 	client.Client
-	Scheme   *runtime.Scheme
-	ConfMgr  *configfile.Manager
-	Labeller *nodelabel.Manager
+	Scheme  *runtime.Scheme
+	ConfMgr *configfile.Manager
 }
 
 // +kubebuilder:rbac:groups=workshop.golab.io,resources=configurations,verbs=get;list;watch;create;update;patch;delete
@@ -62,8 +57,8 @@ type ConfigurationReconciler struct {
 func (r *ConfigurationReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	lh := logf.FromContext(ctx)
 
-	conf := workshopv1alpha1.Configuration{}
-	err := r.Get(ctx, req.NamespacedName, &conf)
+	conf := &workshopv1alpha1.Configuration{}
+	err := r.Get(ctx, req.NamespacedName, conf)
 	if err != nil {
 		// Error reading the object - requeue the request.
 		return ctrl.Result{}, client.IgnoreNotFound(err)
@@ -76,58 +71,34 @@ func (r *ConfigurationReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 
 	if !conf.DeletionTimestamp.IsZero() {
 		// Deletion
-		if controllerutil.ContainsFinalizer(&conf, Finalizer) {
-			err = r.syncForDelete(ctx, lh, &conf)
-			if err != nil {
-				return ctrl.Result{}, err
+		if controllerutil.ContainsFinalizer(conf, Finalizer) {
+			if err := r.ConfMgr.Delete(conf.Spec.Filename); err != nil {
+				return ctrl.Result{}, fmt.Errorf("failed to delete the configuration %q: %w", conf.Spec.Filename, err)
 			}
-			controllerutil.RemoveFinalizer(&conf, Finalizer)
-			err = r.Update(ctx, &conf)
+			controllerutil.RemoveFinalizer(conf, Finalizer)
+			err = r.Update(ctx, conf)
 			return ctrl.Result{}, err
 		}
+		return ctrl.Result{}, nil
 	}
 
 	// Add or Update
-	if !controllerutil.ContainsFinalizer(&conf, Finalizer) {
-		controllerutil.AddFinalizer(&conf, Finalizer)
-		err = r.Update(ctx, &conf)
+	if !controllerutil.ContainsFinalizer(conf, Finalizer) {
+		controllerutil.AddFinalizer(conf, Finalizer)
+		err = r.Update(ctx, conf)
 		if err != nil {
 			return ctrl.Result{}, err
 		}
 	}
 
-	err = r.syncForAddOrUpdate(ctx, lh, &conf)
-	return ctrl.Result{}, err
-}
-
-func (r *ConfigurationReconciler) syncForDelete(ctx context.Context, lh logr.Logger, conf *workshopv1alpha1.Configuration) error {
-	lh.Info("handling deletion requesi", "config", conf.Spec.Filename)
-	err := r.ConfMgr.Delete(conf.Spec.Filename)
-	if err != nil {
-		return fmt.Errorf("failed to delete the configuration %q: %w", conf.Spec.Filename, err)
-	}
-
-	lh.Info("removing node label", "config", conf.Spec.Filename)
-	err = r.Labeller.Clear(ctx, nodelabel.MakeContentHashLabel(conf.Spec.Filename))
-	if err != nil {
-		return fmt.Errorf("failed to delete the node label %q: %w", conf.Spec.Filename, err)
-	}
-	return nil
-}
-
-func (r *ConfigurationReconciler) syncForAddOrUpdate(ctx context.Context, lh logr.Logger, conf *workshopv1alpha1.Configuration) error {
 	oldStatus := conf.Status.DeepCopy()
 	configurationRequest := configurationRequestFromSpec(conf.Spec)
 
-	err := r.ConfMgr.HandleSync(lh, configurationRequest)
+	err = r.ConfMgr.HandleSync(lh, configurationRequest)
 	if errors.As(err, &configfile.NonRecoverableError{}) {
 		lh.Error(err, "Non-recoverable error handling configuration")
-		return nil
+		return ctrl.Result{}, nil
 	}
-
-	contentHash := fmt.Sprintf("%x", sha256.Sum256([]byte(conf.Spec.Content)))[:60]
-	err = r.Labeller.Set(ctx, nodelabel.MakeContentHashLabel(conf.Spec.Filename), contentHash)
-	lh.Info("labelled node", "value", contentHash, "error", err)
 
 	confStatus := r.ConfMgr.Status(configurationRequest.Filename)
 	lh.Info("file status", "fileName", configurationRequest.Filename, "status", confStatus)
@@ -137,10 +108,10 @@ func (r *ConfigurationReconciler) syncForAddOrUpdate(ctx context.Context, lh log
 		updErr := r.Client.Status().Update(ctx, conf)
 		if updErr != nil && !apierrors.IsNotFound(updErr) {
 			lh.Error(updErr, "Failed to update configuration status")
-			return fmt.Errorf("could not update status for object %s: %w", client.ObjectKeyFromObject(conf), updErr)
+			return ctrl.Result{}, fmt.Errorf("could not update status for object %s: %w", client.ObjectKeyFromObject(conf), updErr)
 		}
 	}
-	return err
+	return ctrl.Result{}, nil
 }
 
 // SetupWithManager sets up the controller with the Manager.


### PR DESCRIPTION
- Removing the labelling logic from the implementation and the unit tests
- Fixed a bug, returning early in case of delete instead of falling
  throgh if finalizer was not set and delete timestamp was set
- Remove the wrappers to add and delete, now that we don't have the node
  labelling logic the body is slimmer.